### PR TITLE
libgcode: refactor CRC calcuation

### DIFF
--- a/src/binarize/binarize.cpp
+++ b/src/binarize/binarize.cpp
@@ -414,7 +414,7 @@ EResult BaseMetadataBlock::write(FILE& file, EBlockType block_type, ECompression
         // update checksum with block header
         block_header.update_checksum(checksum);
         // update checksum with block payload
-        checksum.append(encode((const void*)&encoding_type, sizeof(encoding_type)));
+        checksum.append(encoding_type);
         if (!out_data.empty())
             checksum.append(out_data);
     }
@@ -637,9 +637,9 @@ EResult ThumbnailBlock::read_data(FILE& file, const FileHeader& file_header, con
 
 void ThumbnailBlock::update_checksum(Checksum& checksum) const
 {
-    checksum.append(encode((const void*)&params.format, sizeof(params.format)));
-    checksum.append(encode((const void*)&params.width, sizeof(params.width)));
-    checksum.append(encode((const void*)&params.height, sizeof(params.height)));
+    checksum.append(params.format);
+    checksum.append(params.width);
+    checksum.append(params.height);
     checksum.append(data);
 }
 

--- a/src/convert/convert.cpp
+++ b/src/convert/convert.cpp
@@ -6,6 +6,7 @@
 #include <optional>
 #include <functional>
 #include <charconv>
+#include <memory>
 
 namespace bgcode {
 using namespace core;

--- a/src/convert/convert.cpp
+++ b/src/convert/convert.cpp
@@ -518,6 +518,14 @@ BGCODE_CONVERT_EXPORT EResult from_ascii_to_binary(FILE& src_file, FILE& dst_fil
 
 BGCODE_CONVERT_EXPORT EResult from_binary_to_ascii(FILE& src_file, FILE& dst_file, bool verify_checksum)
 {
+    // initialize buffer for checksum calulation, if verify_checksum is true
+    std::unique_ptr<uint8_t> checksum_buffer = nullptr;
+    size_t checksum_buffer_size = 0;
+    if (verify_checksum){
+        checksum_buffer_size = 65535;
+        checksum_buffer.reset(new uint8_t[checksum_buffer_size]);
+    }
+
     auto write_line = [&](const std::string& line) {
         fwrite(line.data(), 1, line.length(), &dst_file);
         return !ferror(&dst_file);
@@ -553,7 +561,7 @@ BGCODE_CONVERT_EXPORT EResult from_binary_to_ascii(FILE& src_file, FILE& dst_fil
     // convert file metadata block
     //
     BlockHeader block_header;
-    res = read_next_block_header(src_file, file_header, block_header, verify_checksum);
+    res = read_next_block_header(src_file, file_header, block_header, checksum_buffer.get(), checksum_buffer_size);
     if (res != EResult::Success)
         // propagate error
         return res;
@@ -573,7 +581,7 @@ BGCODE_CONVERT_EXPORT EResult from_binary_to_ascii(FILE& src_file, FILE& dst_fil
     //
     // convert printer metadata block
     //
-    res = read_next_block_header(src_file, file_header, block_header, verify_checksum);
+    res = read_next_block_header(src_file, file_header, block_header, checksum_buffer.get(), checksum_buffer_size);
     if (res != EResult::Success)
         // propagate error
         return res;
@@ -591,7 +599,7 @@ BGCODE_CONVERT_EXPORT EResult from_binary_to_ascii(FILE& src_file, FILE& dst_fil
     // convert thumbnail blocks
     //
     long restore_position = ftell(&src_file);
-    res = read_next_block_header(src_file, file_header, block_header, verify_checksum);
+    res = read_next_block_header(src_file, file_header, block_header, checksum_buffer.get(), checksum_buffer_size);
     if (res != EResult::Success)
         // propagate error
         return res;
@@ -629,7 +637,7 @@ BGCODE_CONVERT_EXPORT EResult from_binary_to_ascii(FILE& src_file, FILE& dst_fil
             return EResult::WriteError;
 
         restore_position = ftell(&src_file);
-        res = read_next_block_header(src_file, file_header, block_header, verify_checksum);
+        res = read_next_block_header(src_file, file_header, block_header, checksum_buffer.get(), checksum_buffer_size);
         if (res != EResult::Success)
             // propagate error
             return res;
@@ -665,7 +673,7 @@ BGCODE_CONVERT_EXPORT EResult from_binary_to_ascii(FILE& src_file, FILE& dst_fil
     if (res != EResult::Success)
         // propagate error
         return res;
-    res = read_next_block_header(src_file, file_header, block_header, EBlockType::GCode, verify_checksum);
+    res = read_next_block_header(src_file, file_header, block_header, EBlockType::GCode, checksum_buffer.get(), checksum_buffer_size);
     if (res != EResult::Success)
         // propagate error
         return res;
@@ -682,7 +690,7 @@ BGCODE_CONVERT_EXPORT EResult from_binary_to_ascii(FILE& src_file, FILE& dst_fil
         }
         if (ftell(&src_file) == file_size)
             break;
-        res = read_next_block_header(src_file, file_header, block_header, verify_checksum);
+        res = read_next_block_header(src_file, file_header, block_header, checksum_buffer.get(), checksum_buffer_size);
         if (res != EResult::Success)
             // propagate error
             return res;
@@ -692,7 +700,7 @@ BGCODE_CONVERT_EXPORT EResult from_binary_to_ascii(FILE& src_file, FILE& dst_fil
     // convert print metadata block
     //
     fseek(&src_file, restore_position, SEEK_SET);
-    res = read_next_block_header(src_file, file_header, block_header, verify_checksum);
+    res = read_next_block_header(src_file, file_header, block_header, checksum_buffer.get(), checksum_buffer_size);
     if (res != EResult::Success)
         // propagate error
         return res;
@@ -711,7 +719,7 @@ BGCODE_CONVERT_EXPORT EResult from_binary_to_ascii(FILE& src_file, FILE& dst_fil
     //
     // convert slicer metadata block
     //
-    res = read_next_block_header(src_file, file_header, block_header, verify_checksum);
+    res = read_next_block_header(src_file, file_header, block_header, checksum_buffer.get(), checksum_buffer_size);
     if (res != EResult::Success)
         // propagate error
         return res;

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -3,8 +3,6 @@
 
 namespace bgcode { namespace core {
 
-static size_t g_checksum_max_cache_size = 65536;
-
 static bool write_to_file(FILE& file, const void* data, size_t data_size)
 {
     fwrite(data, 1, data_size, &file);
@@ -33,17 +31,15 @@ static uint32_t crc32_sw(const uint8_t* buffer, uint32_t length, uint32_t crc)
     return value;
 }
 
-static std::vector<uint8_t> encode(const void* data, size_t data_size)
+EResult verify_block_checksum(FILE& file, const FileHeader& file_header, const BlockHeader& block_header, uint8_t * calc_buffer, size_t calc_buffer_size)
 {
-    std::vector<uint8_t> ret(data_size);
-    memcpy(ret.data(), data, data_size);
-    return ret;
-}
+    // No checksum in file, no checking, just return success
+    if (file_header.checksum_type == (uint16_t)EChecksumType::None)
+        return EResult::Success;
 
-static EResult checksums_match(FILE& file, const FileHeader& file_header, const BlockHeader& block_header)
-{
-    // cache file position
-    const long curr_pos = ftell(&file);
+    // seek after header, where payload starts
+    if (fseek(&file, block_header.get_position() + (long)block_header.get_size(), SEEK_SET) != 0)
+        return EResult::ReadError;
 
     Checksum curr_cs((EChecksumType)file_header.checksum_type);
     // update block checksum block header
@@ -52,11 +48,10 @@ static EResult checksums_match(FILE& file, const FileHeader& file_header, const 
     // read block payload
     size_t remaining_payload_size = block_payload_size(block_header);
     while (remaining_payload_size > 0) {
-        const size_t size_to_read = std::min(remaining_payload_size, g_checksum_max_cache_size);
-        std::vector<uint8_t> payload(size_to_read);
-        if (!read_from_file(file, payload.data(), payload.size()))
+        const size_t size_to_read = std::min(remaining_payload_size, calc_buffer_size);
+        if (!read_from_file(file, calc_buffer, size_to_read))
             return EResult::ReadError;
-        curr_cs.append(payload);
+        curr_cs.append(calc_buffer, size_to_read);
         remaining_payload_size -= size_to_read;
     }
 
@@ -71,9 +66,6 @@ static EResult checksums_match(FILE& file, const FileHeader& file_header, const 
     if (!curr_cs.matches(read_cs))
         return EResult::InvalidChecksum;
 
-    // restore file position
-    fseek(&file, curr_pos, SEEK_SET);
-
     return EResult::Success;
 }
 
@@ -84,39 +76,38 @@ static uint16_t compression_types_count() { return 1 + (uint16_t)ECompressionTyp
 Checksum::Checksum(EChecksumType type)
 : m_type(type)
 {
-    if (m_type != EChecksumType::None)
-        m_checksum = std::vector<uint8_t>(checksum_size(m_type), '\0');
+    m_checksum.fill(0);
 }
 
 EChecksumType Checksum::get_type() const { return m_type; }
 
-void Checksum::append(const std::vector<uint8_t>& data)
+void Checksum::append(const uint8_t * data, size_t size)
 {
-    size_t remaining_data_size = std::distance(data.begin(), data.end());
-    auto it_begin = data.begin();
-    while (remaining_data_size + m_cache.size() > g_checksum_max_cache_size) {
-        update();
-        if (remaining_data_size > g_checksum_max_cache_size) {
-            m_cache.insert(m_cache.end(), it_begin, it_begin + g_checksum_max_cache_size);
-            it_begin += g_checksum_max_cache_size;
-            remaining_data_size -= g_checksum_max_cache_size;
-        }
+    switch (m_type)
+    {
+    case EChecksumType::None:
+    {
+        break;
     }
-
-    m_cache.insert(m_cache.end(), it_begin, data.end());
+    case EChecksumType::CRC32:
+    {
+        static_assert(sizeof(m_checksum) >= sizeof(uint32_t), "Insufficient size of checksum");
+        const uint32_t old_crc = *(uint32_t*)m_checksum.data();
+        const uint32_t new_crc = crc32_sw(data, size, old_crc);
+        *(uint32_t*)m_checksum.data() = new_crc;
+        break;
+    }
+    }
 }
 
 bool Checksum::matches(Checksum& other)
 {
-    update();
-    other.update();
     return m_checksum == other.m_checksum;
 }
 
 EResult Checksum::write(FILE& file)
 {
     if (m_type != EChecksumType::None) {
-        update();
         if (!write_to_file(file, (const void*)m_checksum.data(), m_checksum.size()))
             return EResult::WriteError;
     }
@@ -130,29 +121,6 @@ EResult Checksum::read(FILE& file)
             return EResult::ReadError;
     }
     return EResult::Success;
-}
-
-void Checksum::update()
-{
-    if (m_cache.empty())
-      return;
-
-    switch (m_type)
-    {
-    case EChecksumType::None:
-    {
-        break;
-    }
-    case EChecksumType::CRC32:
-    {
-        const uint32_t old_crc = *(uint32_t*)m_checksum.data();
-        const uint32_t new_crc = crc32_sw(m_cache.data(), (uint32_t)m_cache.size(), old_crc);
-        *(uint32_t*)m_checksum.data() = new_crc;
-        break;
-    }
-    }
-
-    m_cache.clear();
 }
 
 EResult FileHeader::write(FILE& file) const
@@ -201,11 +169,11 @@ BlockHeader::BlockHeader(uint16_t type, uint16_t compression, uint32_t uncompres
 
 void BlockHeader::update_checksum(Checksum& checksum) const
 {
-    checksum.append(encode((const void*)&type, sizeof(type)));
-    checksum.append(encode((const void*)&compression, sizeof(compression)));
-    checksum.append(encode((const void*)&uncompressed_size, sizeof(uncompressed_size)));
+    checksum.append(type);
+    checksum.append(compression);
+    checksum.append(uncompressed_size);
     if (compression != (uint16_t)ECompressionType::None)
-        checksum.append(encode((const void*)&compressed_size, sizeof(compressed_size)));
+        checksum.append(compressed_size);
 }
 
 long BlockHeader::get_position() const
@@ -276,8 +244,6 @@ EResult ThumbnailParams::read(FILE& file){
     return EResult::Success;
 }
 
-BGCODE_CORE_EXPORT size_t get_checksum_max_cache_size() { return g_checksum_max_cache_size; }
-BGCODE_CORE_EXPORT void set_checksum_max_cache_size(size_t size) { g_checksum_max_cache_size = size; }
 
 BGCODE_CORE_EXPORT std::string_view translate_result(EResult result)
 {
@@ -314,7 +280,7 @@ BGCODE_CORE_EXPORT std::string_view translate_result(EResult result)
     return std::string_view();
 }
 
-BGCODE_CORE_EXPORT EResult is_valid_binary_gcode(FILE& file, bool check_contents)
+BGCODE_CORE_EXPORT EResult is_valid_binary_gcode(FILE& file, bool check_contents, uint8_t *checksum_calc_buffer /*= nullptr*/, size_t checksum_calc_buffer_size /*= 0 */)
 {
     // cache file position
     const long curr_pos = ftell(&file);
@@ -348,7 +314,7 @@ BGCODE_CORE_EXPORT EResult is_valid_binary_gcode(FILE& file, bool check_contents
         }
         BlockHeader block_header;
         // read file metadata block header
-        res = read_next_block_header(file, file_header, block_header, false);
+        res = read_next_block_header(file, file_header, block_header, checksum_calc_buffer, checksum_calc_buffer_size);
         if (res != EResult::Success) {
             // restore file position
             fseek(&file, curr_pos, SEEK_SET);
@@ -369,7 +335,7 @@ BGCODE_CORE_EXPORT EResult is_valid_binary_gcode(FILE& file, bool check_contents
             // propagate error
             return res;
         }
-        res = read_next_block_header(file, file_header, block_header, false);
+        res = read_next_block_header(file, file_header, block_header, checksum_calc_buffer, checksum_calc_buffer_size);
         if (res != EResult::Success) {
             // restore file position
             fseek(&file, curr_pos, SEEK_SET);
@@ -390,7 +356,7 @@ BGCODE_CORE_EXPORT EResult is_valid_binary_gcode(FILE& file, bool check_contents
             // propagate error
             return res;
         }
-        res = read_next_block_header(file, file_header, block_header, false);
+        res = read_next_block_header(file, file_header, block_header, checksum_calc_buffer, checksum_calc_buffer_size);
         if (res != EResult::Success) {
             // restore file position
             fseek(&file, curr_pos, SEEK_SET);
@@ -405,7 +371,7 @@ BGCODE_CORE_EXPORT EResult is_valid_binary_gcode(FILE& file, bool check_contents
                 // propagate error
                 return res;
             }
-            res = read_next_block_header(file, file_header, block_header, false);
+            res = read_next_block_header(file, file_header, block_header, checksum_calc_buffer, checksum_calc_buffer_size);
             if (res != EResult::Success) {
                 // restore file position
                 fseek(&file, curr_pos, SEEK_SET);
@@ -429,7 +395,7 @@ BGCODE_CORE_EXPORT EResult is_valid_binary_gcode(FILE& file, bool check_contents
             // propagate error
             return res;
         }
-        res = read_next_block_header(file, file_header, block_header, false);
+        res = read_next_block_header(file, file_header, block_header, checksum_calc_buffer, checksum_calc_buffer_size);
         if (res != EResult::Success) {
             // restore file position
             fseek(&file, curr_pos, SEEK_SET);
@@ -453,7 +419,7 @@ BGCODE_CORE_EXPORT EResult is_valid_binary_gcode(FILE& file, bool check_contents
             }
             if (ftell(&file) == file_size)
                 break;
-            res = read_next_block_header(file, file_header, block_header, false);
+            res = read_next_block_header(file, file_header, block_header, checksum_calc_buffer, checksum_calc_buffer_size);
             if (res != EResult::Success) {
                 // restore file position
                 fseek(&file, curr_pos, SEEK_SET);
@@ -478,28 +444,27 @@ BGCODE_CORE_EXPORT EResult read_header(FILE& file, FileHeader& header, const uin
     return header.read(file, max_version);
 }
 
-BGCODE_CORE_EXPORT EResult read_next_block_header(FILE& file, const FileHeader& file_header, BlockHeader& block_header, bool verify_checksum)
+BGCODE_CORE_EXPORT EResult read_next_block_header(FILE& file, const FileHeader& file_header, BlockHeader& block_header, uint8_t *checksum_calc_buffer, size_t checksum_calc_buffer_size)
 {
-    if (verify_checksum && (EChecksumType)file_header.checksum_type != EChecksumType::None) {
-        const EResult res = block_header.read(file);
-        if (res != EResult::Success)
-            // propagate error
-            return res;
-
-        return checksums_match(file, file_header, block_header);
+    auto res = block_header.read(file);
+    if (res == EResult::Success && checksum_calc_buffer && checksum_calc_buffer_size)
+    {
+        res = verify_block_checksum(file, file_header, block_header, checksum_calc_buffer, checksum_calc_buffer_size);
+        // return to payload position after checksum verification
+        if (fseek(&file, block_header.get_position() + (long)block_header.get_size(), SEEK_SET) != 0)
+            res = EResult::ReadError;
     }
-    else
-        return block_header.read(file);
+
+    return res;
 }
 
-BGCODE_CORE_EXPORT EResult read_next_block_header(FILE& file, const FileHeader& file_header, BlockHeader& block_header, EBlockType type,
-    bool verify_checksum)
+BGCODE_CORE_EXPORT EResult read_next_block_header(FILE& file, const FileHeader& file_header, BlockHeader& block_header, EBlockType type, uint8_t *checksum_calc_buffer, size_t checksum_calc_buffer_size)
 {
     // cache file position
     const long curr_pos = ftell(&file);
 
     do {
-        EResult res = read_next_block_header(file, file_header, block_header, false);
+        EResult res = read_next_block_header(file, file_header, block_header, nullptr, 0); // intentionally skip checksum verification
         if (res != EResult::Success)
             // propagate error
             return res;
@@ -511,14 +476,15 @@ BGCODE_CORE_EXPORT EResult read_next_block_header(FILE& file, const FileHeader& 
         }
         else if ((EBlockType)block_header.type == type) {
             // block found
-            if (verify_checksum) {
-                res = checksums_match(file, file_header, block_header);
-                if (res != EResult::Success)
-                    // propagate error
-                    return res;
-                else
-                    break;
+            if (checksum_calc_buffer && checksum_calc_buffer_size) {
+                // checksum verification requested
+                res = verify_block_checksum(file, file_header, block_header, checksum_calc_buffer, checksum_calc_buffer_size);
+                // return to payload position after checksum verification
+                if (fseek(&file, block_header.get_position() + (long)block_header.get_size(), SEEK_SET) != 0)
+                    res = EResult::ReadError;
+                return res; // propagate error or success
             }
+            return EResult::Success;
         }
 
         if (!feof(&file)) {
@@ -528,8 +494,6 @@ BGCODE_CORE_EXPORT EResult read_next_block_header(FILE& file, const FileHeader& 
                 return res;
         }
     } while (true);
-
-    return EResult::Success;
 }
 
 BGCODE_CORE_EXPORT size_t block_parameters_size(EBlockType type)

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -77,6 +77,7 @@ Checksum::Checksum(EChecksumType type)
 : m_type(type)
 {
     m_checksum.fill(0);
+    m_size = checksum_size(type);
 }
 
 EChecksumType Checksum::get_type() const { return m_type; }
@@ -91,7 +92,7 @@ void Checksum::append(const uint8_t * data, size_t size)
     }
     case EChecksumType::CRC32:
     {
-        static_assert(sizeof(m_checksum) >= sizeof(uint32_t), "Insufficient size of checksum");
+        static_assert(sizeof(m_checksum) >= sizeof(uint32_t), "Insufficient MAX_CHECKSUM_SIZE");
         const uint32_t old_crc = *(uint32_t*)m_checksum.data();
         const uint32_t new_crc = crc32_sw(data, size, old_crc);
         *(uint32_t*)m_checksum.data() = new_crc;
@@ -108,7 +109,7 @@ bool Checksum::matches(Checksum& other)
 EResult Checksum::write(FILE& file)
 {
     if (m_type != EChecksumType::None) {
-        if (!write_to_file(file, (const void*)m_checksum.data(), m_checksum.size()))
+        if (!write_to_file(file, (const void*)m_checksum.data(), m_size))
             return EResult::WriteError;
     }
     return EResult::Success;
@@ -117,7 +118,7 @@ EResult Checksum::write(FILE& file)
 EResult Checksum::read(FILE& file)
 {
     if (m_type != EChecksumType::None) {
-        if (!read_from_file(file, (void*)m_checksum.data(), m_checksum.size()))
+        if (!read_from_file(file, (void*)m_checksum.data(), m_size))
             return EResult::ReadError;
     }
     return EResult::Success;

--- a/src/core/core.hpp
+++ b/src/core/core.hpp
@@ -106,7 +106,6 @@ public:
     template<typename T, typename = typename std::enable_if<std::is_arithmetic<T>::value, T>::type>
     void append(T &data)
     {
-        static_assert(std::is_fundamental<T>::value, "only for basic types");
         append(reinterpret_cast<const uint8_t*>(&data), sizeof(data));
     }
     // Append data to the checksum
@@ -119,8 +118,11 @@ public:
     EResult read(FILE& file);
 
 private:
+
+    static constexpr size_t MAX_CHECKSUM_SIZE = 4; // max size of biggest checksum supported
+    size_t m_size; // actual size of current checksum
     EChecksumType m_type;
-    std::array<uint8_t, 4> m_checksum;
+    std::array<uint8_t, MAX_CHECKSUM_SIZE> m_checksum;
 };
 
 struct FileHeader

--- a/src/core/core.hpp
+++ b/src/core/core.hpp
@@ -97,9 +97,21 @@ public:
 
     EChecksumType get_type() const;
 
-    // Appends the given data to the cache and performs a checksum update if
-    // the size of the cache exceeds the max checksum cache size.
-    void append(const std::vector<uint8_t>& data);
+    // Append vector of data to checksum
+    void append(const std::vector<uint8_t> &data)
+    {
+        append(data.data(), data.size());
+    }
+    // Append any aritmetic data to the checksum (shorthand for aritmetic types)
+    template<typename T, typename = typename std::enable_if<std::is_arithmetic<T>::value, T>::type>
+    void append(T &data)
+    {
+        static_assert(std::is_fundamental<T>::value, "only for basic types");
+        append(reinterpret_cast<const uint8_t*>(&data), sizeof(data));
+    }
+    // Append data to the checksum
+    void append(const uint8_t * data, size_t size);
+
     // Returns true if the given checksum is equal to this one
     bool matches(Checksum& other);
 
@@ -108,10 +120,7 @@ public:
 
 private:
     EChecksumType m_type;
-    std::vector<uint8_t> m_cache;
-    std::vector<uint8_t> m_checksum;
-
-    void update();
+    std::array<uint8_t, 4> m_checksum;
 };
 
 struct FileHeader
@@ -165,15 +174,10 @@ struct ThumbnailParams
 // Returns a string description of the given result
 extern BGCODE_CORE_EXPORT std::string_view translate_result(EResult result);
 
-// Get the max size of the cache used to calculate checksums, in bytes.
-extern BGCODE_CORE_EXPORT size_t get_checksum_max_cache_size();
-// Set the max size of the cache used to calculate checksums, in bytes.
-extern BGCODE_CORE_EXPORT void set_checksum_max_cache_size(size_t size);
-
 // Returns EResult::Success if the given file is a valid binary gcode
 // If check_contents is set to true, the order of the blocks is checked
 // Does not modify the file position
-extern BGCODE_CORE_EXPORT EResult is_valid_binary_gcode(FILE& file, bool check_contents = false);
+extern BGCODE_CORE_EXPORT EResult is_valid_binary_gcode(FILE& file, bool check_contents = false, uint8_t *checksum_calc_buffer = nullptr, size_t checksum_calc_buffer_size = 0);
 
 // Reads the file header.
 // If max_version is not null, version is checked against the passed value.
@@ -187,7 +191,7 @@ extern BGCODE_CORE_EXPORT EResult read_header(FILE& file, FileHeader& header, co
 // If return == EResult::Success:
 // - block_header will contain the header of the block.
 // - file position will be set at the start of the block parameters data.
-extern BGCODE_CORE_EXPORT EResult read_next_block_header(FILE& file, const FileHeader& file_header, BlockHeader& block_header, bool verify_checksum);
+extern BGCODE_CORE_EXPORT EResult read_next_block_header(FILE& file, const FileHeader& file_header, BlockHeader& block_header, uint8_t *checksum_calc_buffer = nullptr, size_t checksum_calc_buffer_size = 0);
 
 // Searches and reads next block header with the given type from the current file position.
 // File position must be at the start of a block header.
@@ -196,7 +200,16 @@ extern BGCODE_CORE_EXPORT EResult read_next_block_header(FILE& file, const FileH
 // - file position will be set at the start of the block parameters data.
 // otherwise:
 // - file position will keep the current value.
-extern BGCODE_CORE_EXPORT EResult read_next_block_header(FILE& file, const FileHeader& file_header, BlockHeader& block_header, EBlockType type, bool verify_checksum);
+extern BGCODE_CORE_EXPORT EResult read_next_block_header(FILE& file, const FileHeader& file_header, BlockHeader& block_header, EBlockType type, uint8_t *checksum_calc_buffer = nullptr, size_t checksum_calc_buffer_size = 0);
+
+// Calculates block checksum and verify it against checksum stored in file.
+// Caller is responsible for providing buffer for CRC calculation, bigger buffer means faster calculation and vice versa.
+// If return == EResult::Success:
+// - CRC is OK
+// If return == EResult::InvalidChecksum
+// - CRC mismatch
+// Or some other read related error
+extern BGCODE_CORE_EXPORT EResult verify_block_checksum(FILE& file, const FileHeader& file_header, const BlockHeader& block_header, uint8_t * calc_buffer, size_t calc_buffer_size);
 
 // Skips the content (parameters + data + checksum) of the block with the given block header.
 // File position must be at the start of the block parameters.

--- a/tests/core/core_tests.cpp
+++ b/tests/core/core_tests.cpp
@@ -82,15 +82,6 @@ static std::string thumbnail_format_as_string(EThumbnailFormat type)
     return "";
 };
 
-TEST_CASE("Checksum max cache size", "[Core]")
-{
-    std::cout << "\nTEST: Checksum max cache size\n";
-
-    const size_t MAX_CHECKSUM_CACHE_SIZE = 2048;
-    set_checksum_max_cache_size(MAX_CHECKSUM_CACHE_SIZE);
-    const size_t res = get_checksum_max_cache_size();
-    REQUIRE(res == MAX_CHECKSUM_CACHE_SIZE);
-}
 
  TEST_CASE("File transversal", "[Core]")
  {
@@ -99,13 +90,13 @@ TEST_CASE("Checksum max cache size", "[Core]")
      std::cout << "File:" << filename << "\n";
 
      const size_t MAX_CHECKSUM_CACHE_SIZE = 2048;
+     uint8_t checksum_verify_buffer[MAX_CHECKSUM_CACHE_SIZE];
      const bool verify_checksum = true;
-     set_checksum_max_cache_size(MAX_CHECKSUM_CACHE_SIZE);
 
      FILE* file = boost::nowide::fopen(filename.c_str(), "rb");
      REQUIRE(file != nullptr);
      ScopedFile scoped_file(file);
-     REQUIRE(is_valid_binary_gcode(*file) == EResult::Success);
+     REQUIRE(is_valid_binary_gcode(*file, true, checksum_verify_buffer, sizeof(checksum_verify_buffer)) == EResult::Success);
 
      fseek(file, 0, SEEK_END);
      const long file_size = ftell(file);
@@ -120,7 +111,7 @@ TEST_CASE("Checksum max cache size", "[Core]")
      do
      {
          // read block header
-         REQUIRE(read_next_block_header(*file, file_header, block_header, verify_checksum) == EResult::Success);
+         REQUIRE(read_next_block_header(*file, file_header, block_header, checksum_verify_buffer, sizeof(checksum_verify_buffer)) == EResult::Success);
          std::cout << "Block: " << block_type_as_string((EBlockType)block_header.type);
          std::cout << " - compression: " << compression_type_as_string((ECompressionType)block_header.compression);
          switch ((EBlockType)block_header.type)
@@ -177,13 +168,13 @@ TEST_CASE("Checksum max cache size", "[Core]")
      std::cout << "File:" << filename << "\n";
 
      const size_t MAX_CHECKSUM_CACHE_SIZE = 2048;
-     const bool verify_checksum = true;
-     set_checksum_max_cache_size(MAX_CHECKSUM_CACHE_SIZE);
+     uint8_t checksum_verify_buffer[MAX_CHECKSUM_CACHE_SIZE];
+
 
      FILE* file = boost::nowide::fopen(filename.c_str(), "rb");
      REQUIRE(file != nullptr);
      ScopedFile scoped_file(file);
-     REQUIRE(is_valid_binary_gcode(*file) == EResult::Success);
+     REQUIRE(is_valid_binary_gcode(*file, true, checksum_verify_buffer, sizeof(checksum_verify_buffer)) == EResult::Success);
 
      fseek(file, 0, SEEK_END);
      const long file_size = ftell(file);
@@ -197,7 +188,7 @@ TEST_CASE("Checksum max cache size", "[Core]")
      do
      {
          // search and read block header by type
-         REQUIRE(read_next_block_header(*file, file_header, block_header, EBlockType::GCode, verify_checksum) == EResult::Success);
+         REQUIRE(read_next_block_header(*file, file_header, block_header, EBlockType::GCode, checksum_verify_buffer, sizeof(checksum_verify_buffer)) == EResult::Success);
          std::cout << "Block type: " << block_type_as_string((EBlockType)block_header.type) << "\n";
 
          // move to next block header


### PR DESCRIPTION
- remove dynamic allocation & std::vector from core
- user has to provide buffer for calculating CRC
- buffer is no longer shared, so can be used from multiple threads
- avoid unecessary copying between vectors