### PR TITLE
cmake: fix manylinux wheel builds

### DIFF
--- a/pybgcode/CMakeLists.txt
+++ b/pybgcode/CMakeLists.txt
@@ -23,7 +23,7 @@ else ()
     add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/.. ${CMAKE_CURRENT_BINARY_DIR}/upstream)
 endif ()
 
-find_package(Python3 REQUIRED COMPONENTS Interpreter Development)
+find_package(Python3 REQUIRED COMPONENTS Interpreter Development.Module)
 find_package(pybind11 REQUIRED)
 
 set(PY_VERSION_SUFFIX "")


### PR DESCRIPTION
manylinux does not ship with the `Development.Embed` component's static Python libraries, which are implied in the `Development` component, hence builds fail. Those libraries are not needed to build extension modules: https://github.com/scikit-build/scikit-build-core/issues/173

The `Development.Module` sub-component is sufficient for building modules: https://cmake.org/cmake/help/latest/module/FindPython.html

Further references about these sub-components added with cmake 3.18 exactly for the manylinux + cmake combination:
- https://github.com/pypa/manylinux/issues/484
- https://gitlab.kitware.com/cmake/cmake/-/issues/20425

Enabling wheel builds with manylinux allows to use [cibuildwheel](https://github.com/pypa/cibuildwheel) for building multi-platform and multi-arch wheels and potentially making them available on PyPI.